### PR TITLE
Hm 47 email as username

### DIFF
--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/LoginMatchEmailException.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/LoginMatchEmailException.java
@@ -1,6 +1,8 @@
 package org.mitre.healthmanager.service;
 
-public class LoginMatchEmailException extends RuntimeException {
+import javax.validation.ConstraintDeclarationException;
+
+public class LoginMatchEmailException extends ConstraintDeclarationException {
     private static final long serialVersionUID = 1L;
 
     public LoginMatchEmailException() {

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/LoginMatchEmailException.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/LoginMatchEmailException.java
@@ -1,0 +1,9 @@
+package org.mitre.healthmanager.service;
+
+public class LoginMatchEmailException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public LoginMatchEmailException() {
+        super("Login must be the same as email!");
+    }
+}

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
@@ -119,10 +119,6 @@ public class UserService {
 
     public User registerUser(AdminUserDTO userDTO, String password, UserDUADTO userDUADTO) {
         
-        if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
-            throw new LoginMatchEmailException();
-        }
-
         userRepository
             .findOneByLogin(userDTO.getLogin().toLowerCase())
             .ifPresent(existingUser -> {
@@ -139,6 +135,10 @@ public class UserService {
                     throw new EmailAlreadyUsedException();
                 }
             });
+        
+        if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
+            throw new LoginMatchEmailException();
+        }
 
         if (userDUADTO == null || !userDUADTO.getActive() || !userDUADTO.getAgeAttested()) {
             throw new InvalidDUAException();

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
@@ -136,7 +136,7 @@ public class UserService {
                 }
             });
         
-        if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
+        if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userDTO.getLogin())) {
             throw new LoginMatchEmailException();
         }
 

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
@@ -135,10 +135,6 @@ public class UserService {
                     throw new EmailAlreadyUsedException();
                 }
             });
-        
-        if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userDTO.getLogin())) {
-            throw new LoginMatchEmailException();
-        }
 
         if (userDUADTO == null || !userDUADTO.getActive() || !userDUADTO.getAgeAttested()) {
             throw new InvalidDUAException();

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
@@ -118,6 +118,11 @@ public class UserService {
     }
 
     public User registerUser(AdminUserDTO userDTO, String password, UserDUADTO userDUADTO) {
+        
+        if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
+            throw new LoginMatchEmailException();
+        }
+
         userRepository
             .findOneByLogin(userDTO.getLogin().toLowerCase())
             .ifPresent(existingUser -> {

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
@@ -254,9 +254,9 @@ public class UserService {
                 if (userDTO.getEmail() != null) {
                     if (!userDTO.getEmail().equalsIgnoreCase(user.getEmail())) {
                         user.setActivated(false);
+                        user.setActivationKey(RandomUtil.generateActivationKey());
                     } else {
                         user.setActivated(userDTO.isActivated());
-                        user.setActivationKey(RandomUtil.generateActivationKey());
                     }
                     user.setEmail(userDTO.getEmail().toLowerCase());
                     user.setLogin(userDTO.getLogin().toLowerCase());

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/UserService.java
@@ -241,7 +241,7 @@ public class UserService {
      * @param userDTO user to update.
      * @return updated user.
      */
-    public Optional<AdminUserDTO> updateUser(AdminUserDTO userDTO) {
+    public Optional<User> updateUser(AdminUserDTO userDTO) {
         return Optional
             .of(userRepository.findById(userDTO.getId()))
             .filter(Optional::isPresent)
@@ -254,9 +254,9 @@ public class UserService {
                 if (userDTO.getEmail() != null) {
                     if (!userDTO.getEmail().equalsIgnoreCase(user.getEmail())) {
                         user.setActivated(false);
-                        user.setActivationKey(RandomUtil.generateActivationKey());
                     } else {
                         user.setActivated(userDTO.isActivated());
+                        user.setActivationKey(RandomUtil.generateActivationKey());
                     }
                     user.setEmail(userDTO.getEmail().toLowerCase());
                     user.setLogin(userDTO.getLogin().toLowerCase());
@@ -279,8 +279,7 @@ public class UserService {
                 fhirPatientService.createFHIRPatientForUser(user);
 
                 return user;
-            })
-            .map(AdminUserDTO::new);
+            });
     }
 
     public void deleteUser(String login) {
@@ -304,7 +303,7 @@ public class UserService {
      * @param langKey   language key.
      * @param imageUrl  image URL of user.
      */
-    public Optional<AdminUserDTO> updateUser(String firstName, String lastName, String email, String login, String langKey, String imageUrl) {
+    public Optional<User> updateUser(String firstName, String lastName, String email, String login, String langKey, String imageUrl) {
         return SecurityUtils
             .getCurrentUserLogin()
             .map(userRepository::findOneByLogin)
@@ -326,8 +325,7 @@ public class UserService {
                 this.clearUserCaches(user);
                 log.debug("Changed Information for User: {}", user);
                 return user;
-            })
-            .map(AdminUserDTO::new);
+            });
     }
 
     @Transactional("jhipsterTransactionManager")

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/dto/AdminUserDTO.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/dto/AdminUserDTO.java
@@ -11,6 +11,7 @@ import org.mitre.healthmanager.domain.User;
 /**
  * A DTO representing a user, with his authorities.
  */
+@ValidEmailLogin
 public class AdminUserDTO {
 
     private Long id;

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/dto/EmailLoginConstraintValidator.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/dto/EmailLoginConstraintValidator.java
@@ -1,0 +1,21 @@
+package org.mitre.healthmanager.service.dto;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.mitre.healthmanager.service.LoginMatchEmailException;
+
+public class EmailLoginConstraintValidator implements ConstraintValidator<ValidEmailLogin, AdminUserDTO> {
+    @Override
+    public void initialize(ValidEmailLogin arg0) {
+    }
+
+    @Override
+    public boolean isValid(AdminUserDTO userDTO, ConstraintValidatorContext context) {
+        if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userDTO.getLogin())) {
+        	throw new LoginMatchEmailException();        
+        }
+        
+        return true;
+    }
+}

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/dto/ValidEmailLogin.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/dto/ValidEmailLogin.java
@@ -1,0 +1,25 @@
+package org.mitre.healthmanager.service.dto;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = EmailLoginConstraintValidator.class)
+@Target({ TYPE })
+@Retention(RUNTIME)
+public @interface ValidEmailLogin {
+
+    String message() default "Invalid login";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
@@ -137,10 +137,6 @@ public class AccountResource {
         String userLogin = SecurityUtils
             .getCurrentUserLogin()
             .orElseThrow(() -> new AccountResourceException("Current user login not found"));
-        
-        if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
-            throw new LoginMatchEmailException();
-        }
 
         Optional<User> existingUser = userRepository.findOneByEmailIgnoreCase(userDTO.getEmail());
         if (existingUser.isPresent() && (!existingUser.get().getLogin().equalsIgnoreCase(userLogin))) {
@@ -150,6 +146,11 @@ public class AccountResource {
         if (!user.isPresent()) {
             throw new AccountResourceException("User could not be found");
         }
+
+        if (!userDTO.getEmail().toLowerCase().equals(userLogin.toLowerCase())) {
+            throw new LoginMatchEmailException();
+        }
+
         userService.updateUser(
             userDTO.getFirstName(),
             userDTO.getLastName(),

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
@@ -165,7 +165,7 @@ public class AccountResource {
             userDTO.getImageUrl()
         );
 
-        if (newUserDTO.isPresent() && !userDTO.getEmail().equalsIgnoreCase(newUserDTO.get().getEmail())) {
+        if (newUserDTO.isPresent() && !newUserDTO.get().isActivated()) {
             mailService.sendActivationEmail(userMapper.userDTOToUser(newUserDTO.get()));
         }
     }

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
@@ -14,7 +14,6 @@ import org.mitre.healthmanager.service.dto.AdminUserDTO;
 import org.mitre.healthmanager.service.dto.PasswordChangeDTO;
 import org.mitre.healthmanager.service.dto.UserDTO;
 import org.mitre.healthmanager.service.dto.UserDUADTO;
-import org.mitre.healthmanager.service.mapper.UserMapper;
 import org.mitre.healthmanager.web.rest.errors.BadRequestAlertException;
 import org.mitre.healthmanager.web.rest.errors.EmailAlreadyUsedException;
 import org.mitre.healthmanager.web.rest.errors.InvalidPasswordException;
@@ -32,7 +31,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import tech.jhipster.security.RandomUtil;
 
 
 /**
@@ -57,13 +55,11 @@ public class AccountResource {
 
     private final MailService mailService;
 
-    private final UserMapper userMapper;
 
-    public AccountResource(UserRepository userRepository, UserService userService, MailService mailService, UserMapper userMapper) {
+    public AccountResource(UserRepository userRepository, UserService userService, MailService mailService) {
         this.userRepository = userRepository;
         this.userService = userService;
         this.mailService = mailService;
-        this.userMapper = userMapper;
     }
 
     /**
@@ -153,7 +149,7 @@ public class AccountResource {
             throw new AccountResourceException("User could not be found");
         }
 
-        if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userLogin)) {
+        if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userDTO.getLogin())) {
             throw new LoginMatchEmailException();
         }
 

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
@@ -12,13 +12,11 @@ import org.mitre.healthmanager.service.MailService;
 import org.mitre.healthmanager.service.UserService;
 import org.mitre.healthmanager.service.dto.AdminUserDTO;
 import org.mitre.healthmanager.service.dto.PasswordChangeDTO;
-import org.mitre.healthmanager.service.dto.UserDTO;
 import org.mitre.healthmanager.service.dto.UserDUADTO;
 import org.mitre.healthmanager.web.rest.errors.BadRequestAlertException;
 import org.mitre.healthmanager.web.rest.errors.EmailAlreadyUsedException;
 import org.mitre.healthmanager.web.rest.errors.InvalidPasswordException;
 import org.mitre.healthmanager.web.rest.errors.LoginAlreadyUsedException;
-import org.mitre.healthmanager.web.rest.errors.LoginMatchEmailException;
 import org.mitre.healthmanager.web.rest.vm.DUAManagedUserVM;
 import org.mitre.healthmanager.web.rest.vm.KeyAndPasswordVM;
 import org.slf4j.Logger;
@@ -66,7 +64,6 @@ public class AccountResource {
      * {@code POST  /register} : register the user.
      *
      * @param DUAmanagedUserVM the managed user View Model.
-     * @throws LoginMatchEmailException {@code 400 (Bad Request)} if the email and login do not match.
      * @throws InvalidPasswordException {@code 400 (Bad Request)} if the password is incorrect.
      * @throws EmailAlreadyUsedException {@code 400 (Bad Request)} if the email is already used.
      * @throws LoginAlreadyUsedException {@code 400 (Bad Request)} if the login is already used.
@@ -130,7 +127,6 @@ public class AccountResource {
      * {@code POST  /account} : update the current user information.
      *
      * @param userDTO the current user information.
-     * @throws LoginMatchEmailException {@code 400 (Bad Request)} if the email and login do not match.
      * @throws EmailAlreadyUsedException {@code 400 (Bad Request)} if the email is already used.
      * @throws RuntimeException {@code 500 (Internal Server Error)} if the user login wasn't found.
      */
@@ -147,10 +143,6 @@ public class AccountResource {
         Optional<User> user = userRepository.findOneByLogin(userLogin);
         if (!user.isPresent()) {
             throw new AccountResourceException("User could not be found");
-        }
-
-        if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userDTO.getLogin())) {
-            throw new LoginMatchEmailException();
         }
 
         Optional<User> newUser = userService.updateUser(

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
@@ -147,7 +147,7 @@ public class AccountResource {
             throw new AccountResourceException("User could not be found");
         }
 
-        if (!userDTO.getEmail().toLowerCase().equals(userLogin.toLowerCase())) {
+        if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userLogin)) {
             throw new LoginMatchEmailException();
         }
 

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/AccountResource.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.security.RandomUtil;
 
 
 /**
@@ -156,7 +157,7 @@ public class AccountResource {
             throw new LoginMatchEmailException();
         }
 
-        Optional<AdminUserDTO> newUserDTO = userService.updateUser(
+        Optional<User> newUser = userService.updateUser(
             userDTO.getFirstName(),
             userDTO.getLastName(),
             userDTO.getEmail(),
@@ -165,8 +166,8 @@ public class AccountResource {
             userDTO.getImageUrl()
         );
 
-        if (newUserDTO.isPresent() && !newUserDTO.get().isActivated()) {
-            mailService.sendActivationEmail(userMapper.userDTOToUser(newUserDTO.get()));
+        if (newUser.isPresent() && !newUser.get().isActivated()) {
+            mailService.sendActivationEmail(newUser.get());
         }
     }
 

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
@@ -33,7 +33,6 @@ import tech.jhipster.web.util.HeaderUtil;
 import tech.jhipster.web.util.PaginationUtil;
 import tech.jhipster.web.util.ResponseUtil;
 import org.mitre.healthmanager.service.mapper.UserMapper;
-import tech.jhipster.security.RandomUtil;
 
 /**
  * REST controller for managing users.

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
@@ -164,7 +164,7 @@ public class UserResource {
         
         Optional<AdminUserDTO> updatedUser = userService.updateUser(userDTO);
 
-        if (userDTO.getEmail() != null && updatedUser.isPresent() && !userDTO.getEmail().equalsIgnoreCase(updatedUser.get().getEmail())) {
+        if (updatedUser.isPresent() && !updatedUser.get().isActivated()) {
             mailService.sendActivationEmail(userMapper.userDTOToUser(updatedUser.get()));
         }
 

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
@@ -115,12 +115,12 @@ public class UserResource {
         if (userDTO.getId() != null) {
             throw new BadRequestAlertException("A new user cannot already have an ID", "userManagement", "idexists");
             // Lowercase the user login before comparing with database
-        } else if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
-            throw new LoginMatchEmailException();
         } else if (userRepository.findOneByLogin(userDTO.getLogin().toLowerCase()).isPresent()) {
             throw new LoginAlreadyUsedException();
         } else if (userRepository.findOneByEmailIgnoreCase(userDTO.getEmail()).isPresent()) {
             throw new EmailAlreadyUsedException();
+        } else if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
+            throw new LoginMatchEmailException();
         } else {
             User newUser = userService.createUser(userDTO);
             mailService.sendCreationEmail(newUser);
@@ -144,9 +144,6 @@ public class UserResource {
     @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<AdminUserDTO> updateUser(@Valid @RequestBody AdminUserDTO userDTO) {
         log.debug("REST request to update User : {}", userDTO);
-        if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
-            throw new LoginMatchEmailException();
-        }
         Optional<User> existingUser = userRepository.findOneByEmailIgnoreCase(userDTO.getEmail());
         if (existingUser.isPresent() && (!existingUser.get().getId().equals(userDTO.getId()))) {
             throw new EmailAlreadyUsedException();
@@ -154,6 +151,9 @@ public class UserResource {
         existingUser = userRepository.findOneByLogin(userDTO.getLogin().toLowerCase());
         if (existingUser.isPresent() && (!existingUser.get().getId().equals(userDTO.getId()))) {
             throw new LoginAlreadyUsedException();
+        }
+        if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
+            throw new LoginMatchEmailException();
         }
         Optional<AdminUserDTO> updatedUser = userService.updateUser(userDTO);
 

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
@@ -119,7 +119,7 @@ public class UserResource {
             throw new LoginAlreadyUsedException();
         } else if (userRepository.findOneByEmailIgnoreCase(userDTO.getEmail()).isPresent()) {
             throw new EmailAlreadyUsedException();
-        } else if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
+        } else if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userDTO.getLogin())) {
             throw new LoginMatchEmailException();
         } else {
             User newUser = userService.createUser(userDTO);
@@ -152,7 +152,7 @@ public class UserResource {
         if (existingUser.isPresent() && (!existingUser.get().getId().equals(userDTO.getId()))) {
             throw new LoginAlreadyUsedException();
         }
-        if (!userDTO.getEmail().toLowerCase().equals(userDTO.getLogin().toLowerCase())) {
+        if (!userDTO.getLogin().equalsIgnoreCase("admin") && !userDTO.getEmail().equalsIgnoreCase(userDTO.getLogin())) {
             throw new LoginMatchEmailException();
         }
         Optional<AdminUserDTO> updatedUser = userService.updateUser(userDTO);

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/UserResource.java
@@ -33,6 +33,7 @@ import tech.jhipster.web.util.HeaderUtil;
 import tech.jhipster.web.util.PaginationUtil;
 import tech.jhipster.web.util.ResponseUtil;
 import org.mitre.healthmanager.service.mapper.UserMapper;
+import tech.jhipster.security.RandomUtil;
 
 /**
  * REST controller for managing users.
@@ -162,14 +163,21 @@ public class UserResource {
             }
         }
         
-        Optional<AdminUserDTO> updatedUser = userService.updateUser(userDTO);
+        Optional<User> updatedUser = userService.updateUser(userDTO);
 
-        if (updatedUser.isPresent() && !updatedUser.get().isActivated()) {
-            mailService.sendActivationEmail(userMapper.userDTOToUser(updatedUser.get()));
+        if (updatedUser.isPresent() && !updatedUser.get().isActivated()) {     
+            mailService.sendActivationEmail(updatedUser.get());
+        }
+        
+        Optional <AdminUserDTO> updatedUserDTO;
+        if (updatedUser.isPresent()) {
+            updatedUserDTO = Optional.of(userMapper.userToAdminUserDTO(updatedUser.get()));
+        } else {
+            updatedUserDTO = Optional.empty();
         }
 
         return ResponseUtil.wrapOrNotFound(
-            updatedUser,
+            updatedUserDTO,
             HeaderUtil.createAlert(applicationName, "userManagement.updated", userDTO.getLogin())
         );
     }

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/errors/ErrorConstants.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/errors/ErrorConstants.java
@@ -11,6 +11,7 @@ public final class ErrorConstants {
     public static final URI CONSTRAINT_VIOLATION_TYPE = URI.create(PROBLEM_BASE_URL + "/constraint-violation");
     public static final URI INVALID_PASSWORD_TYPE = URI.create(PROBLEM_BASE_URL + "/invalid-password");
     public static final URI EMAIL_ALREADY_USED_TYPE = URI.create(PROBLEM_BASE_URL + "/email-already-used");
+    public static final URI LOGIN_MATCH_EMAIL_ERROR = URI.create(PROBLEM_BASE_URL + "/login-match-email-error");
     public static final URI LOGIN_ALREADY_USED_TYPE = URI.create(PROBLEM_BASE_URL + "/login-already-used");
     public static final URI LOGIN_ALREADY_USED_FHIR_TYPE = URI.create(PROBLEM_BASE_URL + "/login-already-used-fhir");
     public static final URI LOGIN_CHANGED_TYPE = URI.create(PROBLEM_BASE_URL + "/login-changed");

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/errors/ExceptionTranslator.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/errors/ExceptionTranslator.java
@@ -116,6 +116,20 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
     }
 
     @ExceptionHandler
+    public ResponseEntity<Problem> handleLoginMatchEmailException(
+        org.mitre.healthmanager.service.LoginMatchEmailException ex,
+        NativeWebRequest request
+    ) {
+        LoginMatchEmailException problem = new LoginMatchEmailException();
+        return create(
+            problem,
+            request,
+            HeaderUtil.createFailureAlert(applicationName, true, problem.getEntityName(), problem.getErrorKey(), problem.getMessage())
+        );
+    }
+
+
+    @ExceptionHandler
     public ResponseEntity<Problem> handleEmailAlreadyUsedException(
         org.mitre.healthmanager.service.EmailAlreadyUsedException ex,
         NativeWebRequest request

--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/errors/LoginMatchEmailException.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/web/rest/errors/LoginMatchEmailException.java
@@ -1,0 +1,9 @@
+package org.mitre.healthmanager.web.rest.errors;
+
+public class LoginMatchEmailException extends BadRequestAlertException {
+    private static final long serialVersionUID = 1L;
+
+    public LoginMatchEmailException() {
+        super(ErrorConstants.LOGIN_MATCH_EMAIL_ERROR, "Login must be the same as email!", "userManagement", "loginmatchemail");
+    }
+}

--- a/open-health-manager-app/src/main/webapp/i18n/en/global.json
+++ b/open-health-manager-app/src/main/webapp/i18n/en/global.json
@@ -135,6 +135,7 @@
     "Size": "Field {{ fieldName }} does not meet min/max size requirements!",
     "userexists": "Login name already used!",
     "emailexists": "Email is already in use!",
+    "loginmatchemail": "Login must be the same as email!",
     "idexists": "A new {{ entityName }} cannot already have an ID",
     "idnull": "Invalid ID",
     "idinvalid": "Invalid ID",

--- a/open-health-manager-app/src/main/webapp/i18n/en/register.json
+++ b/open-health-manager-app/src/main/webapp/i18n/en/register.json
@@ -17,7 +17,8 @@
       "error": {
         "fail": "<strong>Registration failed!</strong> Please try again later.",
         "userexists": "<strong>Login name already registered!</strong> Please choose another one.",
-        "emailexists": "<strong>Email is already in use!</strong> Please choose another one."
+        "emailexists": "<strong>Email is already in use!</strong> Please choose another one.",
+        "loginmatchemail": "Login must be the same as email!"
       }
     }
   }

--- a/open-health-manager-app/src/main/webapp/i18n/en/settings.json
+++ b/open-health-manager-app/src/main/webapp/i18n/en/settings.json
@@ -12,7 +12,8 @@
     "messages": {
       "error": {
         "fail": "<strong>An error has occurred!</strong> Settings could not be saved.",
-        "emailexists": "<strong>Email is already in use!</strong> Please choose another one."
+        "emailexists": "<strong>Email is already in use!</strong> Please choose another one.",
+        "loginmatchemail": "Login must be the same as email!"
       },
       "success": "<strong>Settings saved!</strong>",
       "validate": {

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/service/UserServiceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/service/UserServiceIT.java
@@ -202,18 +202,6 @@ class UserServiceIT {
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    void assertThatRegisteringWithMismatchedLoginAndEmailFails() {
-        user.setEmail("johndoe12@localhost");
-        AdminUserDTO userDTO = userMapper.userToAdminUserDTO(user);
-
-        LoginMatchEmailException thrown = assertThrows(LoginMatchEmailException.class, () -> userService.registerUser(userDTO, user.getPassword(), userDUADTO));
-        assertEquals("Login must be the same as email!", thrown.getMessage());
-
-        user.setEmail("johndoe@localhost");
-    }
-
-    @Test
-    @Transactional("jhipsterTransactionManager")
     void assertThatRegisteringUsersWithUnActivatedDUAFails() {
         userDUADTO.setActive(false);
         AdminUserDTO userDTO = userMapper.userToAdminUserDTO(user);

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/service/UserServiceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/service/UserServiceIT.java
@@ -38,7 +38,7 @@ import org.mitre.healthmanager.service.mapper.UserMapper;
 @Transactional("jhipsterTransactionManager")
 class UserServiceIT {
 
-    private static final String DEFAULT_LOGIN = "johndoe";
+    private static final String DEFAULT_LOGIN = "johndoe@localhost";
 
     private static final String DEFAULT_EMAIL = "johndoe@localhost";
 
@@ -198,6 +198,18 @@ class UserServiceIT {
         userService.removeNotActivatedUsers();
         Optional<User> maybeDbUser = userRepository.findById(dbUser.getId());
         assertThat(maybeDbUser).contains(dbUser);
+    }
+
+    @Test
+    @Transactional("jhipsterTransactionManager")
+    void assertThatRegisteringWithMismatchedLoginAndEmailFails() {
+        user.setEmail("johndoe12@localhost");
+        AdminUserDTO userDTO = userMapper.userToAdminUserDTO(user);
+
+        LoginMatchEmailException thrown = assertThrows(LoginMatchEmailException.class, () -> userService.registerUser(userDTO, user.getPassword(), userDUADTO));
+        assertEquals("Login must be the same as email!", thrown.getMessage());
+
+        user.setEmail("johndoe@localhost");
     }
 
     @Test

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/AccountResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/AccountResourceIT.java
@@ -871,6 +871,35 @@ class AccountResourceIT {
 
     @Test
     @Transactional("jhipsterTransactionManager")
+    @WithMockUser("admin")
+    void testSaveAccountAdmin() throws Exception {
+        AdminUserDTO userDTO = new AdminUserDTO();
+        userDTO.setLogin("admin");
+        userDTO.setFirstName("firstname");
+        userDTO.setLastName("lastname");
+        userDTO.setEmail("adminnew@localhost");
+        userDTO.setActivated(true);
+        userDTO.setImageUrl("http://placehold.it/50x50");
+        userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
+        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
+
+        restAccountMockMvc
+            .perform(post("/api/account").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(userDTO)))
+            .andExpect(status().isOk());
+
+        User updatedUser = userRepository.findOneWithAuthoritiesByLogin(userDTO.getLogin()).orElse(null);
+        assertThat(updatedUser.getFirstName()).isEqualTo(userDTO.getFirstName());
+        assertThat(updatedUser.getLastName()).isEqualTo(userDTO.getLastName());
+        assertThat(updatedUser.getEmail()).isEqualTo(userDTO.getEmail());
+        assertThat(updatedUser.getLogin()).isEqualTo(userDTO.getLogin());
+        assertThat(updatedUser.getLangKey()).isEqualTo(userDTO.getLangKey());
+        assertThat(updatedUser.getImageUrl()).isEqualTo(userDTO.getImageUrl());
+        assertThat(updatedUser.isActivated()).isFalse();
+        assertThat(updatedUser.getActivationKey()).isNotNull();
+    }
+
+    @Test
+    @Transactional("jhipsterTransactionManager")
     @WithMockUser("save-account-change-email@example.com")
     void testSaveAccountChangeEmail() throws Exception {
         User user = new User();

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/AccountResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/AccountResourceIT.java
@@ -522,13 +522,13 @@ class AccountResourceIT {
 
         firstUser.setUserDUADTO(firstUserDUADTO);
 
-        // Duplicate login, different email
+        // Duplicate login, same email
         DUAManagedUserVM secondUser = new DUAManagedUserVM();
         secondUser.setLogin(firstUser.getLogin());
         secondUser.setPassword(firstUser.getPassword());
         secondUser.setFirstName(firstUser.getFirstName());
         secondUser.setLastName(firstUser.getLastName());
-        secondUser.setEmail("alice2@example.com");
+        secondUser.setEmail(firstUser.getLogin());
         secondUser.setImageUrl(firstUser.getImageUrl());
         secondUser.setLangKey(firstUser.getLangKey());
         secondUser.setAuthorities(new HashSet<>(firstUser.getAuthorities()));
@@ -594,9 +594,10 @@ class AccountResourceIT {
         Optional<User> testUser1 = userRepository.findOneByLogin("test-register-duplicate-email@example.com");
         assertThat(testUser1).isPresent();
 
-        // Duplicate email, different login
+        // Duplicate email, same login
         DUAManagedUserVM secondUser = new DUAManagedUserVM();
-        secondUser.setLogin("test-register-duplicate-email2@example.com");
+        secondUser.setLogin("test-register-duplicate-email@example.com");
+        secondUser.setEmail("test-register-duplicate-email@example.com");
         secondUser.setPassword(firstUser.getPassword());
         secondUser.setFirstName(firstUser.getFirstName());
         secondUser.setLastName(firstUser.getLastName());
@@ -664,7 +665,7 @@ class AccountResourceIT {
         // Duplicate email - with uppercase email address
         DUAManagedUserVM userWithUpperCaseEmail = new DUAManagedUserVM();
         userWithUpperCaseEmail.setId(firstUser.getId());
-        userWithUpperCaseEmail.setLogin("test-register-duplicate-email-upper2@example.com");
+        userWithUpperCaseEmail.setLogin("TEST-register-duplicate-email-upper@example.com");
         userWithUpperCaseEmail.setPassword(firstUser.getPassword());
         userWithUpperCaseEmail.setFirstName(firstUser.getFirstName());
         userWithUpperCaseEmail.setLastName(firstUser.getLastName());
@@ -750,7 +751,7 @@ class AccountResourceIT {
                 userService.createUser(firstUserDTO);
 
                 // confirm a linked FHIR patient exists
-                Optional<User> storedUser = userRepository.findOneByLogin("to-re-register");
+                Optional<User> storedUser = userRepository.findOneByLogin("to-re-register@example.com");
                 assertThat(storedUser).isPresent();
                 FHIRPatient fhirPatient = fhirPatientService.findOneForUser(storedUser.get().getId()).orElse(null);
                 assertNotNull(fhirPatient);
@@ -760,7 +761,7 @@ class AccountResourceIT {
                 IBundleProvider searchResultsPre = patientDAO.search(
                     new SearchParameterMap(
                         "identifier", 
-                        new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "to-re-register")
+                        new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "to-re-register@example.com")
                     ),
                     searchRequestDetails
                 );
@@ -847,7 +848,7 @@ class AccountResourceIT {
                     IBundleProvider searchResultsPre = patientDAO.search(
                         new SearchParameterMap(
                             "identifier", 
-                            new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "activate-account")
+                            new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "activate-account@example.com")
                         ),
                         searchRequestDetails
                     );
@@ -865,7 +866,7 @@ class AccountResourceIT {
                     IBundleProvider searchResultsPost = patientDAO.search(
                         new SearchParameterMap(
                             "identifier", 
-                            new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "activate-account")
+                            new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "activate-account@example.com")
                         ),
                         searchRequestDetails
                     );

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/AccountResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/AccountResourceIT.java
@@ -59,7 +59,7 @@ import ca.uhn.fhir.rest.param.TokenParam;
 @IntegrationTest
 class AccountResourceIT {
 
-    static final String TEST_USER_LOGIN = "test";
+    static final String TEST_USER_LOGIN = "john.doe@jhipster.com";
 
     @Autowired
     private UserRepository userRepository;
@@ -145,7 +145,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterValid() throws Exception {
         DUAManagedUserVM validUser = new DUAManagedUserVM();
-        validUser.setLogin("test-register-valid");
+        validUser.setLogin("test-register-valid@example.com");
         validUser.setPassword("Password135*");
         validUser.setFirstName("Alice");
         validUser.setLastName("Test");
@@ -161,13 +161,13 @@ class AccountResourceIT {
 
         validUser.setUserDUADTO(userDUADTO);
 
-        assertThat(userRepository.findOneByLogin("test-register-valid")).isEmpty();
+        assertThat(userRepository.findOneByLogin("test-register-valid@example.com")).isEmpty();
 
         restAccountMockMvc
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(validUser)))
             .andExpect(status().isCreated());
 
-        Optional<User> findByLogin = userRepository.findOneByLogin("test-register-valid");
+        Optional<User> findByLogin = userRepository.findOneByLogin("test-register-valid@example.com");
         assertThat(findByLogin).isPresent();
         
         // FHIR Patient not created on registration
@@ -178,7 +178,7 @@ class AccountResourceIT {
         IBundleProvider searchResults = patientDAO.search(
             new SearchParameterMap(
                 "identifier", 
-                new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "test-register-valid")
+                new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "test-register-valid@example.com")
             ),
             searchRequestDetails
         );
@@ -189,7 +189,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterInactiveDUA() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("test-register-invalid");
+        invalidUser.setLogin("test-register-invalid@example.com");
         invalidUser.setPassword("Password135*");
         invalidUser.setFirstName("Alice");
         invalidUser.setLastName("Test");
@@ -205,13 +205,13 @@ class AccountResourceIT {
 
         invalidUser.setUserDUADTO(inactiveDUADTO);
 
-        assertThat(userRepository.findOneByLogin("test-register-valid")).isEmpty();
+        assertThat(userRepository.findOneByLogin("test-register-valid@example.com")).isEmpty();
 
         restAccountMockMvc
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(invalidUser)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().is4xxClientError());
 
-        Optional<User> findByLogin = userRepository.findOneByLogin("test-register-invalid");
+        Optional<User> findByLogin = userRepository.findOneByLogin("test-register-invalid@example.com");
         assertThat(findByLogin).isEmpty();
     }
 
@@ -219,7 +219,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterAgeNotAttestedDUA() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("test-register-invalid");
+        invalidUser.setLogin("test-register-invalid@example.com");
         invalidUser.setPassword("Password135*");
         invalidUser.setFirstName("Alice");
         invalidUser.setLastName("Test");
@@ -235,13 +235,13 @@ class AccountResourceIT {
 
         invalidUser.setUserDUADTO(invalidDUADTO);
 
-        assertThat(userRepository.findOneByLogin("test-register-invalid")).isEmpty();
+        assertThat(userRepository.findOneByLogin("test-register-invalid@example.com")).isEmpty();
 
         restAccountMockMvc
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(invalidUser)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().is4xxClientError());
 
-        Optional<User> findByLogin = userRepository.findOneByLogin("test-register-invalid");
+        Optional<User> findByLogin = userRepository.findOneByLogin("test-register-invalid@example.com");
         assertThat(findByLogin).isEmpty();
     }
 
@@ -249,11 +249,11 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterInvalidLogin() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("funky-log(n"); // <-- invalid
+        invalidUser.setLogin("funky-log(n@example.com"); // <-- invalid
         invalidUser.setPassword("Password135*");
         invalidUser.setFirstName("Funky");
         invalidUser.setLastName("One");
-        invalidUser.setEmail("funky@example.com");
+        invalidUser.setEmail("funky-log(n@example.com");
         invalidUser.setActivated(true);
         invalidUser.setImageUrl("http://placehold.it/50x50");
         invalidUser.setLangKey(Constants.DEFAULT_LANGUAGE);
@@ -270,7 +270,7 @@ class AccountResourceIT {
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(invalidUser)))
             .andExpect(status().isBadRequest());
 
-        Optional<User> user = userRepository.findOneByEmailIgnoreCase("funky@example.com");
+        Optional<User> user = userRepository.findOneByEmailIgnoreCase("funky-log(n@example.com");
         assertThat(user).isEmpty();
     }
 
@@ -278,7 +278,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterInvalidEmail() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("bob");
+        invalidUser.setLogin("invalid");
         invalidUser.setPassword("Password135*");
         invalidUser.setFirstName("Bob");
         invalidUser.setLastName("Green");
@@ -299,7 +299,7 @@ class AccountResourceIT {
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(invalidUser)))
             .andExpect(status().isBadRequest());
 
-        Optional<User> user = userRepository.findOneByLogin("bob");
+        Optional<User> user = userRepository.findOneByLogin("invalid");
         assertThat(user).isEmpty();
     }
 
@@ -307,7 +307,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterInvalidPasswordLength() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("bob");
+        invalidUser.setLogin("bob@example.com");
         invalidUser.setPassword("123"); // password with only 3 digits
         invalidUser.setFirstName("Bob");
         invalidUser.setLastName("Green");
@@ -329,7 +329,7 @@ class AccountResourceIT {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='TOO_SHORT')]").exists());
 
-        Optional<User> user = userRepository.findOneByLogin("bob");
+        Optional<User> user = userRepository.findOneByLogin("bob@example.com");
         assertThat(user).isEmpty();
     }
 
@@ -337,7 +337,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterInvalidPasswordNoDigitsNoUppercaseNoSpecial() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("bob");
+        invalidUser.setLogin("bob@example.com");
         invalidUser.setPassword("password");
         invalidUser.setFirstName("Bob");
         invalidUser.setLastName("Green");
@@ -361,7 +361,7 @@ class AccountResourceIT {
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='INSUFFICIENT_UPPERCASE')]").exists())
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='INSUFFICIENT_SPECIAL')]").exists());
 
-        Optional<User> user = userRepository.findOneByLogin("bob");
+        Optional<User> user = userRepository.findOneByLogin("bob@example.com");
         assertThat(user).isEmpty();
     }
 
@@ -369,7 +369,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterInvalidPasswordNoLowercase() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("bob");
+        invalidUser.setLogin("bob@example.com");
         invalidUser.setPassword("PASSWORD12*");
         invalidUser.setFirstName("Bob");
         invalidUser.setLastName("Green");
@@ -391,7 +391,7 @@ class AccountResourceIT {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.fieldErrors[0].message").value("INSUFFICIENT_LOWERCASE"));
 
-        Optional<User> user = userRepository.findOneByLogin("bob");
+        Optional<User> user = userRepository.findOneByLogin("bob@example.com");
         assertThat(user).isEmpty();
     }
 
@@ -399,7 +399,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterInvalidPasswordWhitespaceIllegalSequences() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("bob");
+        invalidUser.setLogin("bob@example.com");
         invalidUser.setPassword("Password 123456ABCDEF*");
         invalidUser.setFirstName("Bob");
         invalidUser.setLastName("Green");
@@ -423,7 +423,7 @@ class AccountResourceIT {
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='ILLEGAL_ALPHABETICAL_SEQUENCE')]").exists())
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='ILLEGAL_NUMERICAL_SEQUENCE')]").exists());
 
-        Optional<User> user = userRepository.findOneByLogin("bob");
+        Optional<User> user = userRepository.findOneByLogin("bob@example.com");
         assertThat(user).isEmpty();
     }
 
@@ -431,7 +431,7 @@ class AccountResourceIT {
     @Transactional("jhipsterTransactionManager")
     void testRegisterNullPassword() throws Exception {
         DUAManagedUserVM invalidUser = new DUAManagedUserVM();
-        invalidUser.setLogin("bob");
+        invalidUser.setLogin("bob@example.com");
         invalidUser.setPassword(null); // invalid null password
         invalidUser.setFirstName("Bob");
         invalidUser.setLastName("Green");
@@ -452,7 +452,7 @@ class AccountResourceIT {
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(invalidUser)))
             .andExpect(status().isBadRequest());
 
-        Optional<User> user = userRepository.findOneByLogin("bob");
+        Optional<User> user = userRepository.findOneByLogin("bob@example.com");
         assertThat(user).isEmpty();
     }
 
@@ -461,7 +461,7 @@ class AccountResourceIT {
     void testRegisterDuplicateLogin() throws Exception {
         // First registration
         DUAManagedUserVM firstUser = new DUAManagedUserVM();
-        firstUser.setLogin("alice");
+        firstUser.setLogin("alice@example.com");
         firstUser.setPassword("Password135*");
         firstUser.setFirstName("Alice");
         firstUser.setLastName("Something");
@@ -507,7 +507,7 @@ class AccountResourceIT {
         // Second (non activated) user
         restAccountMockMvc
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(secondUser)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().isBadRequest());
 
         Optional<User> failedUser = userRepository.findOneByEmailIgnoreCase("alice2@example.com");
         assertThat(failedUser).isEmpty();
@@ -528,7 +528,7 @@ class AccountResourceIT {
     void testRegisterDuplicateEmail() throws Exception {
         // First user
         DUAManagedUserVM firstUser = new DUAManagedUserVM();
-        firstUser.setLogin("test-register-duplicate-email");
+        firstUser.setLogin("test-register-duplicate-email@example.com");
         firstUser.setPassword("Password135*");
         firstUser.setFirstName("Alice");
         firstUser.setLastName("Test");
@@ -550,12 +550,12 @@ class AccountResourceIT {
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(firstUser)))
             .andExpect(status().isCreated());
 
-        Optional<User> testUser1 = userRepository.findOneByLogin("test-register-duplicate-email");
+        Optional<User> testUser1 = userRepository.findOneByLogin("test-register-duplicate-email@example.com");
         assertThat(testUser1).isPresent();
 
         // Duplicate email, different login
         DUAManagedUserVM secondUser = new DUAManagedUserVM();
-        secondUser.setLogin("test-register-duplicate-email-2");
+        secondUser.setLogin("test-register-duplicate-email2@example.com");
         secondUser.setPassword(firstUser.getPassword());
         secondUser.setFirstName(firstUser.getFirstName());
         secondUser.setLastName(firstUser.getLastName());
@@ -574,12 +574,12 @@ class AccountResourceIT {
         // Register second (non activated) user
         restAccountMockMvc
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(secondUser)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().isBadRequest());
 
-        Optional<User> failedUser3 = userRepository.findOneByLogin("test-register-duplicate-email-2");
+        Optional<User> failedUser3 = userRepository.findOneByLogin("test-register-duplicate-email2@example.com");
         assertThat(failedUser3).isEmpty();
 
-        Optional<User> testUser2 = userRepository.findOneByLogin("test-register-duplicate-email");
+        Optional<User> testUser2 = userRepository.findOneByLogin("test-register-duplicate-email@example.com");
         assertThat(testUser2).isPresent();
         testUser2.get().setActivated(true);
         userRepository.save(testUser2.get());
@@ -596,11 +596,11 @@ class AccountResourceIT {
 
         // First user
         DUAManagedUserVM firstUser = new DUAManagedUserVM();
-        firstUser.setLogin("test-register-duplicate-email-uppercase");
+        firstUser.setLogin("test-register-duplicate-email-upper@example.com");
         firstUser.setPassword("Password135*");
         firstUser.setFirstName("Alice");
         firstUser.setLastName("Test");
-        firstUser.setEmail("test-register-duplicate-email-uppercase@example.com");
+        firstUser.setEmail("test-register-duplicate-email-upper@example.com");
         firstUser.setImageUrl("http://placehold.it/50x50");
         firstUser.setLangKey(Constants.DEFAULT_LANGUAGE);
         firstUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
@@ -617,17 +617,17 @@ class AccountResourceIT {
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(firstUser)))
             .andExpect(status().isCreated());
 
-        Optional<User> testUser1 = userRepository.findOneByLogin("test-register-duplicate-email-uppercase");
+        Optional<User> testUser1 = userRepository.findOneByLogin("test-register-duplicate-email-upper@example.com");
         assertThat(testUser1).isPresent();
 
         // Duplicate email - with uppercase email address
         DUAManagedUserVM userWithUpperCaseEmail = new DUAManagedUserVM();
         userWithUpperCaseEmail.setId(firstUser.getId());
-        userWithUpperCaseEmail.setLogin("test-register-duplicate-email-uppercase-2");
+        userWithUpperCaseEmail.setLogin("test-register-duplicate-email-upper2@example.com");
         userWithUpperCaseEmail.setPassword(firstUser.getPassword());
         userWithUpperCaseEmail.setFirstName(firstUser.getFirstName());
         userWithUpperCaseEmail.setLastName(firstUser.getLastName());
-        userWithUpperCaseEmail.setEmail("TEST-register-duplicate-email-uppercase@example.com");
+        userWithUpperCaseEmail.setEmail("TEST-register-duplicate-email-upper@example.com");
         userWithUpperCaseEmail.setImageUrl(firstUser.getImageUrl());
         userWithUpperCaseEmail.setLangKey(firstUser.getLangKey());
         userWithUpperCaseEmail.setAuthorities(new HashSet<>(firstUser.getAuthorities()));
@@ -649,19 +649,19 @@ class AccountResourceIT {
             .andExpect(status().is5xxServerError());
 
        
-        Optional<User> testUser3 = userRepository.findOneByLogin("test-register-duplicate-email-uppercase-2");
+        Optional<User> testUser3 = userRepository.findOneByLogin("test-register-duplicate-email-upper2@example.com");
         assertThat(testUser3).isEmpty();
 
-        Optional<User> testUser2 = userRepository.findOneByLogin("test-register-duplicate-email-uppercase");
+        Optional<User> testUser2 = userRepository.findOneByLogin("test-register-duplicate-email-upper@example.com");
         assertThat(testUser2).isPresent();
-        assertThat(testUser2.get().getEmail()).isEqualTo("test-register-duplicate-email-uppercase@example.com");
+        assertThat(testUser2.get().getEmail()).isEqualTo("test-register-duplicate-email-upper@example.com");
     }
 
     @Test
     @Transactional("jhipsterTransactionManager")
     void testRegisterAdminIsIgnored() throws Exception {
         DUAManagedUserVM validUser = new DUAManagedUserVM();
-        validUser.setLogin("badguy");
+        validUser.setLogin("badguy@example.com");
         validUser.setPassword("Password135*");
         validUser.setFirstName("Bad");
         validUser.setLastName("Guy");
@@ -682,7 +682,7 @@ class AccountResourceIT {
             .perform(post("/api/register").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(validUser)))
             .andExpect(status().isCreated());
 
-        Optional<User> userDup = userRepository.findOneWithAuthoritiesByLogin("badguy");
+        Optional<User> userDup = userRepository.findOneWithAuthoritiesByLogin("badguy@example.com");
         assertThat(userDup).isPresent();
         assertThat(userDup.get().getAuthorities())
             .hasSize(1)
@@ -695,7 +695,7 @@ class AccountResourceIT {
         
         // create activated via service
         AdminUserDTO firstUserDTO = new AdminUserDTO();
-        firstUserDTO.setLogin("to-re-register");
+        firstUserDTO.setLogin("to-re-register@example.com");
         firstUserDTO.setEmail("to-re-register@example.com");
         firstUserDTO.setFirstName("firstname");
         firstUserDTO.setLastName("lastname");
@@ -706,7 +706,7 @@ class AccountResourceIT {
         userService.createUser(firstUserDTO);
         
         // confirm a linked FHIR patient exists
-        Optional<User> storedUser = userRepository.findOneByLogin("to-re-register");
+        Optional<User> storedUser = userRepository.findOneByLogin("to-re-register@example.com");
         assertThat(storedUser).isPresent();
         FHIRPatient fhirPatient = fhirPatientService.findOneForUser(storedUser.get().getId()).orElse(null);
         assertNotNull(fhirPatient);
@@ -716,7 +716,7 @@ class AccountResourceIT {
         IBundleProvider searchResultsPre = patientDAO.search(
             new SearchParameterMap(
                 "identifier", 
-                new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "to-re-register")
+                new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "to-re-register@example.com")
             ),
             searchRequestDetails
         );
@@ -729,7 +729,7 @@ class AccountResourceIT {
 
         // attempt to re-register email with a different login
         DUAManagedUserVM secondUser = new DUAManagedUserVM();
-        secondUser.setLogin("to-re-register-2");
+        secondUser.setLogin("to-re-register-2@example.com");
         secondUser.setPassword("Password135*");
         secondUser.setEmail("to-re-register@example.com");
 
@@ -746,7 +746,7 @@ class AccountResourceIT {
 
         // attempt to re-register login with a different email
         DUAManagedUserVM thirdUser = new DUAManagedUserVM();
-        thirdUser.setLogin("to-re-register");
+        thirdUser.setLogin("to-re-register@example.com");
         thirdUser.setPassword("Password135*");
         thirdUser.setEmail("to-re-register-2@example.com");
 
@@ -768,7 +768,7 @@ class AccountResourceIT {
     void testActivateAccount() throws Exception {
         final String activationKey = "some activation key";
         User user = new User();
-        user.setLogin("activate-account");
+        user.setLogin("activate-account@example.com");
         user.setEmail("activate-account@example.com");
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(false);
@@ -782,7 +782,7 @@ class AccountResourceIT {
         IBundleProvider searchResultsPre = patientDAO.search(
             new SearchParameterMap(
                 "identifier", 
-                new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "activate-account")
+                new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "activate-account@example.com")
             ),
             searchRequestDetails
         );
@@ -796,7 +796,7 @@ class AccountResourceIT {
         IBundleProvider searchResultsPost = patientDAO.search(
             new SearchParameterMap(
                 "identifier", 
-                new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "activate-account")
+                new TokenParam(FHIRPatientService.FHIR_LOGIN_SYSTEM, "activate-account@example.com")
             ),
             searchRequestDetails
         );
@@ -811,10 +811,10 @@ class AccountResourceIT {
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("save-account")
+    @WithMockUser("save-account@example.com")
     void testSaveAccount() throws Exception {
         User user = new User();
-        user.setLogin("save-account");
+        user.setLogin("save-account@example.com");
         user.setEmail("save-account@example.com");
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(true);
@@ -847,10 +847,10 @@ class AccountResourceIT {
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("save-invalid-email")
+    @WithMockUser("save-invalid-email@example.com")
     void testSaveInvalidEmail() throws Exception {
         User user = new User();
-        user.setLogin("save-invalid-email");
+        user.setLogin("save-invalid-email@example.com");
         user.setEmail("save-invalid-email@example.com");
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(true);
@@ -876,17 +876,17 @@ class AccountResourceIT {
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("save-existing-email")
+    @WithMockUser("save-existing-email@example.com")
     void testSaveExistingEmail() throws Exception {
         User user = new User();
-        user.setLogin("save-existing-email");
+        user.setLogin("save-existing-email@example.com");
         user.setEmail("save-existing-email@example.com");
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(true);
         userRepository.saveAndFlush(user);
 
         User anotherUser = new User();
-        anotherUser.setLogin("save-existing-email2");
+        anotherUser.setLogin("save-existing-email2@example.com");
         anotherUser.setEmail("save-existing-email2@example.com");
         anotherUser.setPassword(RandomStringUtils.random(60));
         anotherUser.setActivated(true);
@@ -907,16 +907,16 @@ class AccountResourceIT {
             .perform(post("/api/account").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(userDTO)))
             .andExpect(status().isBadRequest());
 
-        User updatedUser = userRepository.findOneByLogin("save-existing-email").orElse(null);
+        User updatedUser = userRepository.findOneByLogin("save-existing-email@example.com").orElse(null);
         assertThat(updatedUser.getEmail()).isEqualTo("save-existing-email@example.com");
     }
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("save-existing-email-and-login")
+    @WithMockUser("save-existing-email-and-login@example.com")
     void testSaveExistingEmailAndLogin() throws Exception {
         User user = new User();
-        user.setLogin("save-existing-email-and-login");
+        user.setLogin("save-existing-email-and-login@example.com");
         user.setEmail("save-existing-email-and-login@example.com");
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(true);
@@ -936,19 +936,19 @@ class AccountResourceIT {
             .perform(post("/api/account").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(userDTO)))
             .andExpect(status().isOk());
 
-        User updatedUser = userRepository.findOneByLogin("save-existing-email-and-login").orElse(null);
+        User updatedUser = userRepository.findOneByLogin("save-existing-email-and-login@example.com").orElse(null);
         assertThat(updatedUser.getEmail()).isEqualTo("save-existing-email-and-login@example.com");
     }
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("change-password-wrong-existing-password")
+    @WithMockUser("wrong-existing-password@example.com")
     void testChangePasswordWrongExistingPassword() throws Exception {
         User user = new User();
         String currentPassword = RandomStringUtils.random(60);
         user.setPassword(passwordEncoder.encode(currentPassword));
-        user.setLogin("change-password-wrong-existing-password");
-        user.setEmail("change-password-wrong-existing-password@example.com");
+        user.setLogin("wrong-existing-password@example.com");
+        user.setEmail("wrong-existing-password@example.com");
         userRepository.saveAndFlush(user);
 
         restAccountMockMvc
@@ -959,19 +959,19 @@ class AccountResourceIT {
             )
             .andExpect(status().isBadRequest());
 
-        User updatedUser = userRepository.findOneByLogin("change-password-wrong-existing-password").orElse(null);
+        User updatedUser = userRepository.findOneByLogin("wrong-existing-password@example.com").orElse(null);
         assertThat(passwordEncoder.matches("Password135*", updatedUser.getPassword())).isFalse();
         assertThat(passwordEncoder.matches(currentPassword, updatedUser.getPassword())).isTrue();
     }
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("change-password")
+    @WithMockUser("change-password@example.com")
     void testChangePassword() throws Exception {
         User user = new User();
         String currentPassword = RandomStringUtils.random(60);
         user.setPassword(passwordEncoder.encode(currentPassword));
-        user.setLogin("change-password");
+        user.setLogin("change-password@example.com");
         user.setEmail("change-password@example.com");
         userRepository.saveAndFlush(user);
 
@@ -983,18 +983,18 @@ class AccountResourceIT {
             )
             .andExpect(status().isOk());
 
-        User updatedUser = userRepository.findOneByLogin("change-password").orElse(null);
+        User updatedUser = userRepository.findOneByLogin("change-password@example.com").orElse(null);
         assertThat(passwordEncoder.matches("Password135*", updatedUser.getPassword())).isTrue();
     }
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("change-password-too-small")
+    @WithMockUser("change-password-too-small@example.com")
     void testChangePasswordTooSmall() throws Exception {
         User user = new User();
         String currentPassword = RandomStringUtils.random(60);
         user.setPassword(passwordEncoder.encode(currentPassword));
-        user.setLogin("change-password-too-small");
+        user.setLogin("change-password-too-small@example.com");
         user.setEmail("change-password-too-small@example.com");
         userRepository.saveAndFlush(user);
 
@@ -1009,18 +1009,18 @@ class AccountResourceIT {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='TOO_SHORT')]").exists());;
 
-        User updatedUser = userRepository.findOneByLogin("change-password-too-small").orElse(null);
+        User updatedUser = userRepository.findOneByLogin("change-password-too-small@example.com").orElse(null);
         assertThat(updatedUser.getPassword()).isEqualTo(user.getPassword());
     }
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("change-password-too-long")
+    @WithMockUser("change-password-too-long@example.com")
     void testChangePasswordTooLong() throws Exception {
         User user = new User();
         String currentPassword = RandomStringUtils.random(60);
         user.setPassword(passwordEncoder.encode(currentPassword));
-        user.setLogin("change-password-too-long");
+        user.setLogin("change-password-too-long@example.com");
         user.setEmail("change-password-too-long@example.com");
         userRepository.saveAndFlush(user);
 
@@ -1035,18 +1035,18 @@ class AccountResourceIT {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='TOO_LONG')]").exists());
 
-        User updatedUser = userRepository.findOneByLogin("change-password-too-long").orElse(null);
+        User updatedUser = userRepository.findOneByLogin("change-password-too-long@example.com").orElse(null);
         assertThat(updatedUser.getPassword()).isEqualTo(user.getPassword());
     }
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("change-password-invalid")
+    @WithMockUser("change-password-invalid@example.com")
     void testChangePasswordInvalidPassword() throws Exception {
         User user = new User();
         String currentPassword = RandomStringUtils.random(60);
         user.setPassword(passwordEncoder.encode(currentPassword));
-        user.setLogin("change-password-invalid");
+        user.setLogin("change-password-invalid@example.com");
         user.setEmail("change-password-invalid@example.com");
         userRepository.saveAndFlush(user);
 
@@ -1063,18 +1063,18 @@ class AccountResourceIT {
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='INSUFFICIENT_DIGIT')]").exists())
             .andExpect(jsonPath("$.fieldErrors[?(@.message=='INSUFFICIENT_SPECIAL')]").exists());
 
-        User updatedUser = userRepository.findOneByLogin("change-password-invalid").orElse(null);
+        User updatedUser = userRepository.findOneByLogin("change-password-invalid@example.com").orElse(null);
         assertThat(updatedUser.getPassword()).isEqualTo(user.getPassword());
     }
 
     @Test
     @Transactional("jhipsterTransactionManager")
-    @WithMockUser("change-password-empty")
+    @WithMockUser("change-password-empty@example.com")
     void testChangePasswordEmpty() throws Exception {
         User user = new User();
         String currentPassword = RandomStringUtils.random(60);
         user.setPassword(passwordEncoder.encode(currentPassword));
-        user.setLogin("change-password-empty");
+        user.setLogin("change-password-empty@example.com");
         user.setEmail("change-password-empty@example.com");
         userRepository.saveAndFlush(user);
 
@@ -1086,7 +1086,7 @@ class AccountResourceIT {
             )
             .andExpect(status().isBadRequest());
 
-        User updatedUser = userRepository.findOneByLogin("change-password-empty").orElse(null);
+        User updatedUser = userRepository.findOneByLogin("change-password-empty@example.com").orElse(null);
         assertThat(updatedUser.getPassword()).isEqualTo(user.getPassword());
     }
 
@@ -1096,7 +1096,7 @@ class AccountResourceIT {
         User user = new User();
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(true);
-        user.setLogin("password-reset");
+        user.setLogin("password-reset@example.com");
         user.setEmail("password-reset@example.com");
         userRepository.saveAndFlush(user);
 
@@ -1111,7 +1111,7 @@ class AccountResourceIT {
         User user = new User();
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(true);
-        user.setLogin("password-reset-upper-case");
+        user.setLogin("password-reset-upper-case@example.com");
         user.setEmail("password-reset-upper-case@example.com");
         userRepository.saveAndFlush(user);
 
@@ -1132,7 +1132,7 @@ class AccountResourceIT {
     void testFinishPasswordReset() throws Exception {
         User user = new User();
         user.setPassword(RandomStringUtils.random(60));
-        user.setLogin("finish-password-reset");
+        user.setLogin("finish-password-reset@example.com");
         user.setEmail("finish-password-reset@example.com");
         user.setResetDate(Instant.now().plusSeconds(60));
         user.setResetKey("reset key");
@@ -1159,7 +1159,7 @@ class AccountResourceIT {
     void testFinishPasswordResetTooSmall() throws Exception {
         User user = new User();
         user.setPassword(RandomStringUtils.random(60));
-        user.setLogin("finish-password-reset-too-small");
+        user.setLogin("finish-password-reset-too-small@example.com");
         user.setEmail("finish-password-reset-too-small@example.com");
         user.setResetDate(Instant.now().plusSeconds(60));
         user.setResetKey("reset key too small");

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/AccountResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/AccountResourceIT.java
@@ -845,7 +845,7 @@ class AccountResourceIT {
         userRepository.saveAndFlush(user);
 
         AdminUserDTO userDTO = new AdminUserDTO();
-        userDTO.setLogin("not-used");
+        userDTO.setLogin("save-account@example.com");
         userDTO.setFirstName("firstname");
         userDTO.setLastName("lastname");
         userDTO.setEmail("save-account@example.com");
@@ -869,6 +869,44 @@ class AccountResourceIT {
         assertThat(updatedUser.getAuthorities()).isEmpty();
     }
 
+    @Test
+    @Transactional("jhipsterTransactionManager")
+    @WithMockUser("save-account-change-email@example.com")
+    void testSaveAccountChangeEmail() throws Exception {
+        User user = new User();
+        user.setLogin("save-account-change-email@example.com");
+        user.setEmail("save-account-change-email@example.com");
+        user.setPassword(RandomStringUtils.random(60));
+        user.setActivated(true);
+        userRepository.saveAndFlush(user);
+
+        AdminUserDTO userDTO = new AdminUserDTO();
+        userDTO.setLogin("save-account-change-email_new@example.com");
+        userDTO.setFirstName("firstname");
+        userDTO.setLastName("lastname");
+        userDTO.setEmail("save-account-change-email_new@example.com");
+        userDTO.setActivated(true);
+        userDTO.setImageUrl("http://placehold.it/50x50");
+        userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
+        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
+
+        restAccountMockMvc
+            .perform(post("/api/account").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(userDTO)))
+            .andExpect(status().isOk());
+
+        User updatedUser = userRepository.findOneWithAuthoritiesByLogin(user.getLogin()).orElse(null);
+        assertThat(updatedUser.getFirstName()).isEqualTo(userDTO.getFirstName());
+        assertThat(updatedUser.getLastName()).isEqualTo(userDTO.getLastName());
+        assertThat(updatedUser.getEmail()).isEqualTo(userDTO.getEmail());
+        assertThat(updatedUser.getLangKey()).isEqualTo(userDTO.getLangKey());
+        assertThat(updatedUser.getPassword()).isEqualTo(user.getPassword());
+        assertThat(updatedUser.getImageUrl()).isEqualTo(userDTO.getImageUrl());
+        assertThat(updatedUser.isActivated()).isFalse();
+        assertThat(updatedUser.getActivationKey()).isNotNull();
+        assertThat(updatedUser.getAuthorities()).isEmpty();
+    }
+
+
 
     @Test
     @Transactional("jhipsterTransactionManager")
@@ -883,7 +921,7 @@ class AccountResourceIT {
         userRepository.saveAndFlush(user);
 
         AdminUserDTO userDTO = new AdminUserDTO();
-        userDTO.setLogin("not-used");
+        userDTO.setLogin("save-mismatch-login-email@example.com");
         userDTO.setFirstName("firstname");
         userDTO.setLastName("lastname");
         userDTO.setEmail("save-mismatch-login-email2@example.com");
@@ -912,7 +950,7 @@ class AccountResourceIT {
         userRepository.saveAndFlush(user);
 
         AdminUserDTO userDTO = new AdminUserDTO();
-        userDTO.setLogin("not-used");
+        userDTO.setLogin("invalid email");
         userDTO.setFirstName("firstname");
         userDTO.setLastName("lastname");
         userDTO.setEmail("invalid email");
@@ -948,7 +986,7 @@ class AccountResourceIT {
         userRepository.saveAndFlush(anotherUser);
 
         AdminUserDTO userDTO = new AdminUserDTO();
-        userDTO.setLogin("not-used");
+        userDTO.setLogin("save-existing-email2@example.com");
         userDTO.setFirstName("firstname");
         userDTO.setLastName("lastname");
         userDTO.setEmail("save-existing-email2@example.com");
@@ -977,7 +1015,7 @@ class AccountResourceIT {
         userRepository.saveAndFlush(user);
 
         AdminUserDTO userDTO = new AdminUserDTO();
-        userDTO.setLogin("not-used");
+        userDTO.setLogin("save-existing-email-and-login@example.com");
         userDTO.setFirstName("firstname");
         userDTO.setLastName("lastname");
         userDTO.setEmail("save-existing-email-and-login@example.com");

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/PublicUserResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/PublicUserResourceIT.java
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @IntegrationTest
 class PublicUserResourceIT {
 
-    private static final String DEFAULT_LOGIN = "johndoe";
+    private static final String DEFAULT_LOGIN = "johndoe@localhost";
 
     @Autowired
     private UserRepository userRepository;

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/UserResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/UserResourceIT.java
@@ -503,6 +503,54 @@ class UserResourceIT {
 
     @Test
     @Transactional("jhipsterTransactionManager")
+    void updateUserAdmin() throws Exception {
+        String methodName = "updateUserAdmin";
+        log.info("**** " + methodName + " ****");
+        
+        int databaseSizeBeforeUpdate = userRepository.findAll().size();
+
+        // Update the user
+        User updatedUser = userRepository.findOneByLogin("admin").get();
+
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setId(updatedUser.getId());
+        managedUserVM.setLogin(updatedUser.getLogin());
+        managedUserVM.setPassword(UPDATED_PASSWORD);
+        managedUserVM.setFirstName(UPDATED_FIRSTNAME);
+        managedUserVM.setLastName(UPDATED_LASTNAME);
+        managedUserVM.setEmail("adminnew@localhost");
+        managedUserVM.setActivated(updatedUser.isActivated());
+        managedUserVM.setImageUrl(UPDATED_IMAGEURL);
+        managedUserVM.setLangKey(UPDATED_LANGKEY);
+        managedUserVM.setCreatedBy(updatedUser.getCreatedBy());
+        managedUserVM.setCreatedDate(updatedUser.getCreatedDate());
+        managedUserVM.setLastModifiedBy(updatedUser.getLastModifiedBy());
+        managedUserVM.setLastModifiedDate(updatedUser.getLastModifiedDate());
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+
+        restUserMockMvc
+            .perform(
+                put("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(managedUserVM))
+            )
+            .andExpect(status().isOk());
+
+        // Validate the User in the database
+        assertPersistedUsers(users -> {
+            assertThat(users).hasSize(databaseSizeBeforeUpdate);
+            User testUser = users.stream().filter(usr -> usr.getId().equals(updatedUser.getId())).findFirst().get();
+            assertThat(testUser.getLogin()).isEqualTo("admin");
+            assertThat(testUser.getEmail()).isEqualTo("adminnew@localhost");
+            assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
+            assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);
+            assertThat(testUser.getImageUrl()).isEqualTo(UPDATED_IMAGEURL);
+            assertThat(testUser.getLangKey()).isEqualTo(UPDATED_LANGKEY);
+            assertThat(testUser.isActivated()).isFalse();
+            assertThat(testUser.getActivationKey()).isNotNull();
+        });
+    }
+
+    @Test
+    @Transactional("jhipsterTransactionManager")
     void updateUserLogin() throws Exception {
         String methodName = "updateUserLogin";
         log.info("**** " + methodName + " ****");

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/UserResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/UserResourceIT.java
@@ -534,18 +534,20 @@ class UserResourceIT {
             .perform(
                 put("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(managedUserVM))
             )
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isOk());
 
-        // Validate no changes to the user
+        // Validate the User in the database
         assertPersistedUsers(users -> {
             assertThat(users).hasSize(databaseSizeBeforeUpdate);
             User testUser = users.stream().filter(usr -> usr.getId().equals(updatedUser.getId())).findFirst().get();
-            assertThat(testUser.getLogin()).isEqualTo(DEFAULT_LOGIN);
-            assertThat(testUser.getFirstName()).isEqualTo(DEFAULT_FIRSTNAME);
-            assertThat(testUser.getLastName()).isEqualTo(DEFAULT_LASTNAME);
-            assertThat(testUser.getEmail()).isEqualTo(DEFAULT_EMAIL);
-            assertThat(testUser.getImageUrl()).isEqualTo(DEFAULT_IMAGEURL);
-            assertThat(testUser.getLangKey()).isEqualTo(DEFAULT_LANGKEY);
+            assertThat(testUser.getLogin()).isEqualTo(UPDATED_LOGIN);
+            assertThat(testUser.getEmail()).isEqualTo(UPDATED_EMAIL);
+            assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
+            assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);
+            assertThat(testUser.getImageUrl()).isEqualTo(UPDATED_IMAGEURL);
+            assertThat(testUser.getLangKey()).isEqualTo(UPDATED_LANGKEY);
+            assertThat(testUser.isActivated()).isFalse();
+            assertThat(testUser.getActivationKey()).isNotNull();
         });
     }
 

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/UserResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/UserResourceIT.java
@@ -213,6 +213,37 @@ class UserResourceIT {
         assertEquals(fhirPatient.getFhirId(), searchResults.getAllResourceIds().get(0));
 
     } 
+
+    @Test
+    @Transactional("jhipsterTransactionManager")
+    void createUserMismatchLoginAndEmail() throws Exception {
+        String methodName = "createUserMismatchLoginAndEmail";
+        log.info("**** " + methodName + " ****");
+        // Initialize the database
+        userRepository.saveAndFlush(user);
+        int databaseSizeBeforeCreate = userRepository.findAll().size();
+
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setLogin(methodName.toLowerCase());
+        managedUserVM.setPassword(DEFAULT_PASSWORD);
+        managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
+        managedUserVM.setLastName(DEFAULT_LASTNAME);
+        managedUserVM.setEmail(methodName.toLowerCase() + DEFAULT_EMAIL_SUFFIX);
+        managedUserVM.setActivated(true);
+        managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
+        managedUserVM.setLangKey(DEFAULT_LANGKEY);
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+
+        // Create the User
+        restUserMockMvc
+            .perform(
+                post("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(managedUserVM))
+            )
+            .andExpect(status().isBadRequest());
+
+        // Validate the User in the database
+        assertPersistedUsers(users -> assertThat(users).hasSize(databaseSizeBeforeCreate));
+    }
  
     @Test
     @Transactional("jhipsterTransactionManager")
@@ -516,6 +547,40 @@ class UserResourceIT {
             assertThat(testUser.getImageUrl()).isEqualTo(DEFAULT_IMAGEURL);
             assertThat(testUser.getLangKey()).isEqualTo(DEFAULT_LANGKEY);
         });
+    }
+
+    @Test
+    @Transactional("jhipsterTransactionManager")
+    void updateUserMismatchLoginAndEmail() throws Exception {
+        String methodName = "updateUserMismatchLoginAndEmail";
+        log.info("**** " + methodName + " ****");
+        // Initialize the database with user
+        userRepository.saveAndFlush(user);
+
+        // Update the user
+        User updatedUser = userRepository.findById(user.getId()).get();
+
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setId(updatedUser.getId());
+        managedUserVM.setLogin(updatedUser.getLogin());
+        managedUserVM.setPassword(updatedUser.getPassword());
+        managedUserVM.setFirstName(updatedUser.getFirstName());
+        managedUserVM.setLastName(updatedUser.getLastName());
+        managedUserVM.setEmail("1234" + updatedUser.getEmail());
+        managedUserVM.setActivated(updatedUser.isActivated());
+        managedUserVM.setImageUrl(updatedUser.getImageUrl());
+        managedUserVM.setLangKey(updatedUser.getLangKey());
+        managedUserVM.setCreatedBy(updatedUser.getCreatedBy());
+        managedUserVM.setCreatedDate(updatedUser.getCreatedDate());
+        managedUserVM.setLastModifiedBy(updatedUser.getLastModifiedBy());
+        managedUserVM.setLastModifiedDate(updatedUser.getLastModifiedDate());
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+
+        restUserMockMvc
+            .perform(
+                put("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(managedUserVM))
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/UserResourceIT.java
+++ b/open-health-manager-app/src/test/java/org/mitre/healthmanager/web/rest/UserResourceIT.java
@@ -55,8 +55,8 @@ import ca.uhn.fhir.rest.param.TokenParam;
 @IntegrationTest
 class UserResourceIT {
 
-    private static final String DEFAULT_LOGIN = "johndoe";
-    private static final String UPDATED_LOGIN = "jhipster";
+    private static final String DEFAULT_LOGIN = "johndoe@localhost";
+    private static final String UPDATED_LOGIN = "jhipster@localhost";
 
     private static final Long DEFAULT_ID = 1L;
 
@@ -119,10 +119,11 @@ class UserResourceIT {
      */
     public static User createEntity(EntityManager em) {
         User user = new User();
-        user.setLogin(DEFAULT_LOGIN + RandomStringUtils.randomAlphabetic(5));
+        String randomAlphabetic = RandomStringUtils.randomAlphabetic(5);
+        user.setLogin(randomAlphabetic + DEFAULT_LOGIN);
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(true);
-        user.setEmail(RandomStringUtils.randomAlphabetic(5) + DEFAULT_EMAIL);
+        user.setEmail(randomAlphabetic + DEFAULT_EMAIL);
         user.setFirstName(DEFAULT_FIRSTNAME);
         user.setLastName(DEFAULT_LASTNAME);
         user.setImageUrl(DEFAULT_IMAGEURL);
@@ -150,7 +151,7 @@ class UserResourceIT {
     void createUser() throws Exception {
         String methodName = "createUser";
         log.info("**** " + methodName + " ****");
-        String testLogin = methodName.toLowerCase();
+        String testLogin = methodName.toLowerCase() + DEFAULT_EMAIL_SUFFIX;
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
         // Create the User
@@ -159,7 +160,7 @@ class UserResourceIT {
         managedUserVM.setPassword(DEFAULT_PASSWORD);
         managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
         managedUserVM.setLastName(DEFAULT_LASTNAME);
-        managedUserVM.setEmail(testLogin + DEFAULT_EMAIL_SUFFIX);
+        managedUserVM.setEmail(testLogin);
         managedUserVM.setActivated(true);
         managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
         managedUserVM.setLangKey(DEFAULT_LANGKEY);
@@ -178,7 +179,7 @@ class UserResourceIT {
             assertThat(testUser.getLogin()).isEqualTo(testLogin);
             assertThat(testUser.getFirstName()).isEqualTo(DEFAULT_FIRSTNAME);
             assertThat(testUser.getLastName()).isEqualTo(DEFAULT_LASTNAME);
-            assertThat(testUser.getEmail()).isEqualTo(testLogin + DEFAULT_EMAIL_SUFFIX);
+            assertThat(testUser.getEmail()).isEqualTo(testLogin);
             assertThat(testUser.getImageUrl()).isEqualTo(DEFAULT_IMAGEURL);
             assertThat(testUser.getLangKey()).isEqualTo(DEFAULT_LANGKEY);
         });
@@ -218,7 +219,7 @@ class UserResourceIT {
     void createUserWithExistingId() throws Exception {
         String methodName = "createUserWithExistingId";
         log.info("**** " + methodName + " ****");
-        String testLogin = methodName.toLowerCase();
+        String testLogin = methodName.toLowerCase() + DEFAULT_EMAIL_SUFFIX;
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
         ManagedUserVM managedUserVM = new ManagedUserVM();
@@ -227,7 +228,7 @@ class UserResourceIT {
         managedUserVM.setPassword(DEFAULT_PASSWORD);
         managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
         managedUserVM.setLastName(DEFAULT_LASTNAME);
-        managedUserVM.setEmail(testLogin + DEFAULT_EMAIL_SUFFIX);
+        managedUserVM.setEmail(testLogin);
         managedUserVM.setActivated(true);
         managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
         managedUserVM.setLangKey(DEFAULT_LANGKEY);
@@ -280,7 +281,7 @@ class UserResourceIT {
     void createUserWithExistingEmail() throws Exception {
         String methodName = "createUserWithExistingEmail";
         log.info("**** " + methodName + " ****");
-        String testLogin = methodName.toLowerCase();
+        String testLogin = methodName.toLowerCase() + DEFAULT_EMAIL_SUFFIX;
         // Initialize the database
         userRepository.saveAndFlush(user);
         int databaseSizeBeforeCreate = userRepository.findAll().size();
@@ -312,7 +313,7 @@ class UserResourceIT {
     void createUserWithFHIRPatientUsername() throws Exception {
         String methodName = "createUserWithFHIRPatientUsername";
         log.info("**** " + methodName + " ****");
-        String testLogin = methodName.toLowerCase();
+        String testLogin = methodName.toLowerCase() + DEFAULT_EMAIL_SUFFIX;
         // Initialize the database
         IFhirResourceDao<Patient> patientDAO = myDaoRegistry.getResourceDao(Patient.class);
         Patient patientFHIR = new Patient();
@@ -343,7 +344,7 @@ class UserResourceIT {
         managedUserVM.setPassword(DEFAULT_PASSWORD);
         managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
         managedUserVM.setLastName(DEFAULT_LASTNAME);
-        managedUserVM.setEmail(testLogin + DEFAULT_EMAIL_SUFFIX);
+        managedUserVM.setEmail(testLogin);
         managedUserVM.setActivated(true);
         managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
         managedUserVM.setLangKey(DEFAULT_LANGKEY);
@@ -441,7 +442,7 @@ class UserResourceIT {
         managedUserVM.setPassword(UPDATED_PASSWORD);
         managedUserVM.setFirstName(UPDATED_FIRSTNAME);
         managedUserVM.setLastName(UPDATED_LASTNAME);
-        managedUserVM.setEmail(UPDATED_EMAIL);
+        managedUserVM.setEmail(DEFAULT_EMAIL); // can't change email since email must equal login
         managedUserVM.setActivated(updatedUser.isActivated());
         managedUserVM.setImageUrl(UPDATED_IMAGEURL);
         managedUserVM.setLangKey(UPDATED_LANGKEY);
@@ -463,7 +464,7 @@ class UserResourceIT {
             User testUser = users.stream().filter(usr -> usr.getId().equals(updatedUser.getId())).findFirst().get();
             assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
             assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);
-            assertThat(testUser.getEmail()).isEqualTo(UPDATED_EMAIL);
+            assertThat(testUser.getEmail()).isEqualTo(DEFAULT_EMAIL);
             assertThat(testUser.getImageUrl()).isEqualTo(UPDATED_IMAGEURL);
             assertThat(testUser.getLangKey()).isEqualTo(UPDATED_LANGKEY);
         });
@@ -526,7 +527,7 @@ class UserResourceIT {
         userRepository.saveAndFlush(user);
 
         User anotherUser = new User();
-        anotherUser.setLogin("jhipster");
+        anotherUser.setLogin("jhipster@localhost");
         anotherUser.setPassword(RandomStringUtils.random(60));
         anotherUser.setActivated(true);
         anotherUser.setEmail("jhipster@localhost");
@@ -571,10 +572,10 @@ class UserResourceIT {
         userRepository.saveAndFlush(user);
 
         User anotherUser = new User();
-        anotherUser.setLogin("jhipster");
+        anotherUser.setLogin("jhipster123@localhost");
         anotherUser.setPassword(RandomStringUtils.random(60));
         anotherUser.setActivated(true);
-        anotherUser.setEmail("jhipster@localhost");
+        anotherUser.setEmail("jhipster123@localhost");
         anotherUser.setFirstName("java");
         anotherUser.setLastName("hipster");
         anotherUser.setImageUrl("");
@@ -586,7 +587,7 @@ class UserResourceIT {
 
         ManagedUserVM managedUserVM = new ManagedUserVM();
         managedUserVM.setId(updatedUser.getId());
-        managedUserVM.setLogin("jhipster"); // this login should already be used by anotherUser
+        managedUserVM.setLogin("jhipster123@localhost"); // this login should already be used by anotherUser
         managedUserVM.setPassword(updatedUser.getPassword());
         managedUserVM.setFirstName(updatedUser.getFirstName());
         managedUserVM.setLastName(updatedUser.getLastName());
@@ -639,7 +640,7 @@ class UserResourceIT {
     void createAdminUser() throws Exception {
         String methodName = "createUser";
         log.info("**** " + methodName + " ****");
-        String testLogin = methodName.toLowerCase();
+        String testLogin = methodName.toLowerCase() + DEFAULT_EMAIL_SUFFIX;
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
         // Create the User
@@ -648,7 +649,7 @@ class UserResourceIT {
         managedUserVM.setPassword(DEFAULT_PASSWORD);
         managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
         managedUserVM.setLastName(DEFAULT_LASTNAME);
-        managedUserVM.setEmail(testLogin + DEFAULT_EMAIL_SUFFIX);
+        managedUserVM.setEmail(testLogin);
         managedUserVM.setActivated(true);
         managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
         managedUserVM.setLangKey(DEFAULT_LANGKEY);
@@ -667,7 +668,7 @@ class UserResourceIT {
             assertThat(testUser.getLogin()).isEqualTo(testLogin);
             assertThat(testUser.getFirstName()).isEqualTo(DEFAULT_FIRSTNAME);
             assertThat(testUser.getLastName()).isEqualTo(DEFAULT_LASTNAME);
-            assertThat(testUser.getEmail()).isEqualTo(testLogin + DEFAULT_EMAIL_SUFFIX);
+            assertThat(testUser.getEmail()).isEqualTo(testLogin);
             assertThat(testUser.getImageUrl()).isEqualTo(DEFAULT_IMAGEURL);
             assertThat(testUser.getLangKey()).isEqualTo(DEFAULT_LANGKEY);
         });


### PR DESCRIPTION
Update API user management services to force email to exactly match username for account create and update requests.

Changes in this PR:
- Update API account create and update calls to throw bad request exception if username and email not exact match.
- Change API so that username can be updated after registration