### PR TITLE
FHIR Patient Creation Bug Fix

### DIFF
--- a/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/FHIRPatientService.java
+++ b/open-health-manager-app/src/main/java/org/mitre/healthmanager/service/FHIRPatientService.java
@@ -179,6 +179,8 @@ public class FHIRPatientService {
 
     	// do not create FHIR Patient if user not activated or not ROLE_USER
     	if(!user.isActivated() || 
+                user.getAuthorities().stream().map(Authority::getName)
+                .anyMatch(authority -> authority.equals(AuthoritiesConstants.ADMIN)) ||
     			user.getAuthorities().stream().map(Authority::getName)
     			.noneMatch(authority -> authority.equals(AuthoritiesConstants.USER))) {
     		return null;


### PR DESCRIPTION
Put in a fix to check that the user roles do not include ROLE_ADMIN when creating the FHIR Patient in the backend, since admin accounts are also assigned ROLE_USER 