### PR TITLE
Hm 146 Pregnancy Mapping Observation

### DIFF
--- a/open-health-manager-lib/src/main/java/org/mitre/healthmanager/lib/pdr/PdrIntegrationConfig.java
+++ b/open-health-manager-lib/src/main/java/org/mitre/healthmanager/lib/pdr/PdrIntegrationConfig.java
@@ -1,5 +1,6 @@
 package org.mitre.healthmanager.lib.pdr;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -155,18 +156,28 @@ public class PdrIntegrationConfig {
 	}
 	
 	@Aggregator
-	public Bundle aggregatingMethod(List<BundleEntryComponent> items) {
+	public Bundle aggregatingMethod(List<List<BundleEntryComponent>> items) {
 	    Bundle result = new Bundle();
-		for(BundleEntryComponent item: items) {
-			result.addEntry(item);
-	    }
+		for (List<BundleEntryComponent> bundleEntryList : items) {
+			for(BundleEntryComponent item: bundleEntryList) {
+				result.addEntry(item);
+			}
+		}
 		return result;
 	}
 	
 	@ServiceActivator
-	public BundleEntryComponent recordMatch(@Payload BundleEntryComponent entry, @Header("messageHeader") MessageHeader messageHeader,
+	public List<BundleEntryComponent> recordMatch(@Payload List<BundleEntryComponent> bundle, @Header("messageHeader") MessageHeader messageHeader,
 			@Header("internalPatientId") @NotNull String internalPatientId) {
-		return recordMatchService.recordMatch(entry, internalPatientId, messageHeader, daoRegistry);		
+		
+		List<BundleEntryComponent> bundleEntryList = new ArrayList<BundleEntryComponent>();
+		
+		for (BundleEntryComponent entry : bundle) {
+			BundleEntryComponent recordMatch =  recordMatchService.recordMatch(entry, internalPatientId, messageHeader, daoRegistry);
+			bundleEntryList.add(recordMatch);
+		}	
+
+		return bundleEntryList;
 	}
 		
 	@ServiceActivator

--- a/open-health-manager-lib/src/main/java/org/mitre/healthmanager/lib/pdr/PdrIntegrationConfig.java
+++ b/open-health-manager-lib/src/main/java/org/mitre/healthmanager/lib/pdr/PdrIntegrationConfig.java
@@ -167,12 +167,12 @@ public class PdrIntegrationConfig {
 	}
 	
 	@ServiceActivator
-	public List<BundleEntryComponent> recordMatch(@Payload List<BundleEntryComponent> bundle, @Header("messageHeader") MessageHeader messageHeader,
+	public List<BundleEntryComponent> recordMatch(@Payload List<BundleEntryComponent> entries, @Header("messageHeader") MessageHeader messageHeader,
 			@Header("internalPatientId") @NotNull String internalPatientId) {
 		
 		List<BundleEntryComponent> bundleEntryList = new ArrayList<BundleEntryComponent>();
 		
-		for (BundleEntryComponent entry : bundle) {
+		for (BundleEntryComponent entry : entries) {
 			BundleEntryComponent recordMatch =  recordMatchService.recordMatch(entry, internalPatientId, messageHeader, daoRegistry);
 			bundleEntryList.add(recordMatch);
 		}	

--- a/open-health-manager-lib/src/main/java/org/mitre/healthmanager/lib/pdr/data/AppleHealthKitService.java
+++ b/open-health-manager-lib/src/main/java/org/mitre/healthmanager/lib/pdr/data/AppleHealthKitService.java
@@ -1,10 +1,7 @@
 package org.mitre.healthmanager.lib.pdr.data;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Date;
 import java.util.List;
 
 import javax.validation.constraints.NotNull;
@@ -18,11 +15,9 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.DateTimeType;
-import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Immunization;
 import org.hl7.fhir.r4.model.Observation;
-import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Procedure;
 import org.hl7.fhir.r4.model.Property;
 import org.hl7.fhir.r4.model.Reference;
@@ -133,6 +128,11 @@ public class AppleHealthKitService extends DataTransformer {
 
 				observationList.add(observation);
 			}
+		}
+		
+		if(observationList.isEmpty()) {
+			// bad data - sample entry should at least include startDate
+			throw new UnprocessableEntityException("Unprocessable sample type: HKCategoryTypeIdentifierPregnancy");		
 		}
 			
 		return observationList;

--- a/open-health-manager-lib/src/main/java/org/mitre/healthmanager/lib/pdr/data/DataTransformer.java
+++ b/open-health-manager-lib/src/main/java/org/mitre/healthmanager/lib/pdr/data/DataTransformer.java
@@ -1,10 +1,12 @@
 package org.mitre.healthmanager.lib.pdr.data;
 
+import java.util.List;
+
 import javax.validation.constraints.NotNull;
 
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.springframework.messaging.handler.annotation.Header;
 
 public abstract class DataTransformer {
-	abstract BundleEntryComponent transform(BundleEntryComponent entry, @Header("internalPatientId") @NotNull String internalPatientId);
+	abstract List<BundleEntryComponent> transform(BundleEntryComponent entry, @Header("internalPatientId") @NotNull String internalPatientId);
 }

--- a/open-health-manager-lib/src/test/java/org/mitre/healthmanager/lib/pdr/data/AppleHealthKitServiceTest.java
+++ b/open-health-manager-lib/src/test/java/org/mitre/healthmanager/lib/pdr/data/AppleHealthKitServiceTest.java
@@ -2,6 +2,7 @@ package org.mitre.healthmanager.lib.pdr.data;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.List;
 
 import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.Bundle;
@@ -25,12 +26,14 @@ class AppleHealthKitServiceTest {
 		Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
 		entry.setResource(binary);
 		
-		Bundle.BundleEntryComponent result = ahk.transformBundleEntry(entry, "user-2");
+		List<Bundle.BundleEntryComponent> resultList = ahk.transformBundleEntry(entry, "user-2");
 		
-		Assertions.assertNotNull(result);
-		Assertions.assertEquals(result.getResource().getResourceType().name(), "Condition");
-		Condition condition = (Condition) result.getResource();
-		Assertions.assertEquals(condition.getSubject().getReferenceElement().getIdPart(), "user-2");
-		Assertions.assertNull(condition.getAsserter().getReferenceElement().getValue());
+		for (Bundle.BundleEntryComponent result : resultList) {
+			Assertions.assertNotNull(result);
+			Assertions.assertEquals(result.getResource().getResourceType().name(), "Condition");
+			Condition condition = (Condition) result.getResource();
+			Assertions.assertEquals(condition.getSubject().getReferenceElement().getIdPart(), "user-2");
+			Assertions.assertNull(condition.getAsserter().getReferenceElement().getValue());
+		}
 	}
 }

--- a/open-health-manager-lib/src/test/java/org/mitre/healthmanager/lib/pdr/data/AppleHealthKitServiceTest.java
+++ b/open-health-manager-lib/src/test/java/org/mitre/healthmanager/lib/pdr/data/AppleHealthKitServiceTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Observation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -35,5 +36,40 @@ class AppleHealthKitServiceTest {
 			Assertions.assertEquals(condition.getSubject().getReferenceElement().getIdPart(), "user-2");
 			Assertions.assertNull(condition.getAsserter().getReferenceElement().getValue());
 		}
+	}
+
+	@Test
+	void testConvertPregnancy() throws IOException {
+
+		String pregnancyMessage = "{\"uuid\":\"24827DF1-BB01-4D39-A3C5-3F29A4C8FC5B\",\"value\":\"notApplicable\",\"startDate\":\"2022-09-03\",\"endDate\":\"2023-06-03\",\"sampleType\":\"HKCategoryTypeIdentifierPregnancy\"}";
+
+		Binary pregnancyResource = new Binary();
+		pregnancyResource.setContentType("application/json");
+		pregnancyResource.setContentAsBase64(Base64.getEncoder().encodeToString(pregnancyMessage.getBytes()));
+		
+		Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+		entry.setResource(pregnancyResource);
+		
+		List<Bundle.BundleEntryComponent> resultList = ahk.transformBundleEntry(entry, "user-2");
+		Assertions.assertEquals(2, resultList.size());
+		for (Bundle.BundleEntryComponent result : resultList) {
+			Assertions.assertNotNull(result);
+			Assertions.assertEquals("Observation", result.getResource().getResourceType().name());
+			Observation observation = (Observation) result.getResource();
+			Assertions.assertEquals(observation.getSubject().getReferenceElement().getIdPart(), "user-2");
+		}
+
+		pregnancyMessage= "{\"uuid\":\"34827DF1-BB01-4D39-A3C5-3F29A4C8FC5B\",\"value\":\"notApplicable\",\"startDate\":\"2022-09-03\",\"endDate\":\"4000-12-31\",\"sampleType\":\"HKCategoryTypeIdentifierPregnancy\"}";
+		pregnancyResource.setContentAsBase64(Base64.getEncoder().encodeToString(pregnancyMessage.getBytes()));
+
+		resultList = ahk.transformBundleEntry(entry, "user-2");
+		Assertions.assertEquals(1, resultList.size());
+		for (Bundle.BundleEntryComponent result : resultList) {
+			Assertions.assertNotNull(result);
+			Assertions.assertEquals("Observation", result.getResource().getResourceType().name());
+			Observation observation = (Observation) result.getResource();
+			Assertions.assertEquals(observation.getSubject().getReferenceElement().getIdPart(), "user-2");
+		}
+
 	}
 }


### PR DESCRIPTION
Changes in this PR:

Modify HealthKit pregnancy mapping to use the US Core Pregnancy Status Observation resource rather than a Condition resource. Since the US Core Pregnancy Status Observation uses a DateTime for its effective date, it creates two Observation resources for each pregnancy message received from the Apple Health Kit, one for the pregnancy start date, and one for the end date if a valid end date is provided. Due to this, the PdrIntegrationConfig needed to be updated to be able to handle a list of Bundle Entry Components, rather than a single Bundle Entry Component. 